### PR TITLE
krait actually has a L1 cache size of 32KB

### DIFF
--- a/projects/D85X-Kernel-Gamma/Makefile
+++ b/projects/D85X-Kernel-Gamma/Makefile
@@ -68,7 +68,7 @@ export QCOM_S801 := \
         -mvectorize-with-neon-quad \
         -mno-unaligned-access \
         --param l1-cache-line-size=64 \
-        --param l1-cache-size=16 \
+        --param l1-cache-size=32 \
         --param l2-cache-size=2048 \
 
 export GRAPHTIE_FLAGS := \


### PR DESCRIPTION
16 KB + 16 KB 4-way set associative L1 cache

https://www.notebookcheck.net/Qualcomm-Snapdragon-801-MSM8974AC-SoC.112062.0.html
https://en.wikipedia.org/wiki/Krait_(CPU)